### PR TITLE
Add missing openmp linking flag

### DIFF
--- a/configure
+++ b/configure
@@ -89,7 +89,7 @@ DEBUG=""
 LIBNAME=""
 
 CXXFLAGS="-std=c++11 -Wall -Wno-unused-local-typedefs -fopenmp -I. -I$SRCDIR/include"
-LDFLAGS=""
+LDFLAGS="-fopenmp"
 SOFLAGS="-shared"
 DEPLIBS="OpenCL"
 TARGET=""


### PR DESCRIPTION
This fixes ```symbol lookup error: /usr/lib/vapoursynth/libknlmeanscl.so: undefined symbol: GOMP_parallel``` some linux users are reporting.