### PR TITLE
Fix https://github.com/Khanattila/KNLMeansCL/issues/18

### DIFF
--- a/configure
+++ b/configure
@@ -88,7 +88,7 @@ DEBUG=""
 
 LIBNAME=""
 
-CXXFLAGS="-std=c++11 -Wall -Wno-unused-local-typedefs -I. -I./shared -I$SRCDIR/include"
+CXXFLAGS="-std=gnu++11 -Wall -Wno-unused-local-typedefs -I. -I./shared -I$SRCDIR/include"
 LDFLAGS=""
 SOFLAGS="-shared"
 DEPLIBS="OpenCL"


### PR DESCRIPTION
Change `c++11` to `gnu++11` fix https://github.com/Khanattila/KNLMeansCL/issues/18 with GCC 6.1.x