### PR TITLE
ocl_utils.cpp: add cstring header include

### DIFF
--- a/KNLMeansCL/shared/ocl_utils.cpp
+++ b/KNLMeansCL/shared/ocl_utils.cpp
@@ -18,6 +18,7 @@
 
 #include "ocl_utils.h"
 #include <fstream>
+#include <cstring>
 
 #define STR(code) case code: return #code
 


### PR DESCRIPTION
Currently the strstr() function is called, which resides in `#include <cstring>` but the include is missing. This just adds it in. 