### PR TITLE
Fixes for AviSynth+ on *nix

### DIFF
--- a/KNLMeansCL/NLMAvisynth.cpp
+++ b/KNLMeansCL/NLMAvisynth.cpp
@@ -39,6 +39,10 @@
 #   define AVS_EXPORT
 #endif
 
+#ifndef _WIN32
+#define __AVISYNTH_8_H__ // force this on unconditionally in *nix
+#endif
+
 #ifdef __AVISYNTH_8_H__
 
 //////////////////////////////////////////

--- a/KNLMeansCL/NLMAvisynth.cpp
+++ b/KNLMeansCL/NLMAvisynth.cpp
@@ -31,6 +31,14 @@
 #    define strcasecmp _stricmp
 #endif
 
+#if defined(_WIN32)
+#   define AVS_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#   define AVS_EXPORT __attribute__((visibility("default")))
+#else
+#   define AVS_EXPORT
+#endif
+
 #ifdef __AVISYNTH_8_H__
 
 //////////////////////////////////////////
@@ -1120,7 +1128,7 @@ AVSValue __cdecl AviSynthPluginCreate(AVSValue args, void* user_data, IScriptEnv
 //////////////////////////////////////////
 // AviSynthPluginInit
 const AVS_Linkage *AVS_linkage = 0;
-extern "C" __declspec(dllexport) const char* __stdcall AvisynthPluginInit3(
+extern "C" AVS_EXPORT const char* __stdcall AvisynthPluginInit3(
     IScriptEnvironment* env, const AVS_Linkage * const vectors)
 {
     AVS_linkage = vectors;

--- a/KNLMeansCL/NLMAvisynth.h
+++ b/KNLMeansCL/NLMAvisynth.h
@@ -26,9 +26,11 @@
 #    include <avisynth.h>
 #else
 #    include <avisynth/avisynth.h>
+#    define __AVISYNTH_8_H__ // force this on unconditionally on *nix
 #endif
 
 #ifdef __AVISYNTH_8_H__
+
 struct NLMAvisynth : public GenericVideoFilter {
 
 private:

--- a/KNLMeansCL/NLMAvisynth.h
+++ b/KNLMeansCL/NLMAvisynth.h
@@ -24,6 +24,8 @@
 
 #ifdef _WIN32
 #    include <avisynth.h>
+#else
+#    include <avisynth/avisynth.h>
 #endif
 
 #ifdef __AVISYNTH_8_H__

--- a/KNLMeansCL/NLMVapoursynth.h
+++ b/KNLMeansCL/NLMVapoursynth.h
@@ -22,8 +22,13 @@
 #include "NLMKernel.h"
 #include "shared/ocl_utils.h"
 
+#ifdef _WIN32
 #include <VapourSynth.h>
 #include <VSHelper.h>
+#else
+#include <vapoursynth/VapourSynth.h>
+#include <vapoursynth/VSHelper.h>
+#endif
 
 #ifdef VAPOURSYNTH_H
 

--- a/meson.build
+++ b/meson.build
@@ -43,5 +43,19 @@ library(
     'knlmeanscl',
     src,
     dependencies : deps,
-    install_dir : join_paths(get_option('prefix'), get_option('libdir'), 'vapoursynth'),
+    install_dir : join_paths(get_option('prefix'), get_option('libdir')),
     install : true)
+
+if avisynth.found()
+install_symlink(
+    'libknlmeanscl.so',
+    install_dir : join_paths(get_option('prefix'), get_option('libdir'), 'avisynth'),
+    pointing_to : '../libknlmeanscl.so' )
+endif
+
+if vapoursynth.found()
+install_symlink(
+    'libknlmeanscl.so',
+    install_dir : join_paths(get_option('prefix'), get_option('libdir'), 'vapoursynth'),
+    pointing_to : '../libknlmeanscl.so')
+endif

--- a/meson.build
+++ b/meson.build
@@ -4,8 +4,9 @@ project('KNLMeansCL',
         license : 'GPL-3',
         version : '1.1.1')
 
+avisynth = dependency('avisynth')
 vapoursynth = dependency('vapoursynth')
-deps = [vapoursynth]
+deps = [avisynth, vapoursynth]
 
 opencl_dep = dependency('OpenCL', required : false)
 if not opencl_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -8,8 +8,10 @@ avisynth = dependency('avisynth', required : false)
 avisynth_src = ['KNLMeansCL/NLMAvisynth.h',
                 'KNLMeansCL/NLMAvisynth.cpp']
 
-vapoursynth = dependency('vapoursynth')
-deps = [vapoursynth]
+vapoursynth = dependency('vapoursynth', required : false)
+vapoursynth_src = ['KNLMeansCL/NLMVapoursynth.cpp',
+                   'KNLMeansCL/NLMVapoursynth.h',]
+deps = []
 
 opencl_dep = dependency('OpenCL', required : false)
 if not opencl_dep.found()
@@ -22,8 +24,6 @@ src = [
     'KNLMeansCL/NLMDefault.h',
     'KNLMeansCL/NLMKernel.cpp',
     'KNLMeansCL/NLMKernel.h',
-    'KNLMeansCL/NLMVapoursynth.cpp',
-    'KNLMeansCL/NLMVapoursynth.h',
     'KNLMeansCL/shared/common.cpp',
     'KNLMeansCL/shared/common.h',
     'KNLMeansCL/shared/ocl_utils.cpp',
@@ -34,6 +34,10 @@ src = [
 if avisynth.found()
     src += [avisynth_src]
 endif
+
+if vapoursynth.found()
+    src += [vapoursynth_src]
+ endif
 
 library(
     'knlmeanscl',

--- a/meson.build
+++ b/meson.build
@@ -4,9 +4,12 @@ project('KNLMeansCL',
         license : 'GPL-3',
         version : '1.1.1')
 
-avisynth = dependency('avisynth')
+avisynth = dependency('avisynth', required : false)
+avisynth_src = ['KNLMeansCL/NLMAvisynth.h',
+                'KNLMeansCL/NLMAvisynth.cpp']
+
 vapoursynth = dependency('vapoursynth')
-deps = [avisynth, vapoursynth]
+deps = [vapoursynth]
 
 opencl_dep = dependency('OpenCL', required : false)
 if not opencl_dep.found()
@@ -16,8 +19,6 @@ boost_dep = dependency('boost', modules : ['filesystem', 'system'])
 deps += [opencl_dep, boost_dep]
 
 src = [
-    'KNLMeansCL/NLMAvisynth.h',
-    'KNLMeansCL/NLMAvisynth.cpp',
     'KNLMeansCL/NLMDefault.h',
     'KNLMeansCL/NLMKernel.cpp',
     'KNLMeansCL/NLMKernel.h',
@@ -29,6 +30,10 @@ src = [
     'KNLMeansCL/shared/ocl_utils.h',
     'KNLMeansCL/shared/startchar.cpp',
     'KNLMeansCL/shared/startchar.h']
+
+if avisynth.found()
+    src += [avisynth_src]
+endif
 
 library(
     'knlmeanscl',


### PR DESCRIPTION
Basically also a fix for https://github.com/pinterf/KNLMeansCL/issues/2, because the AviSynth plugin lacked the GCC visibility thing that needs to be adjusted for vs. Windows' `__declspec(dllexport)`.  That bit was copied from LSMASHSource.

Assumes that *nix users are going to want to use the installed (currently v9) headers, which additionally caused issues with the `#ìfdef __AVISYNTH_8_H__` in NLMAvisynth.{h|cpp}.  I'll admit that that commit is a complete hack; it probably should have a better version detection setup.  Feel free to replace that with a better option if you want.  Since anyone compiling 3.7.2 from source is going to get v9 headers, and virtually all of the distros that package AviSynth+ ship 3.7.2 or would otherwise rely on users building it themselves, I'd be willing to bet almost no-one is going to have pre-v8 headers on their system to screw it up.

Using this patchset I was able to confirm that 1) the plugin works on Linux, but also 2) the GPU's OpenCL functionality is in fact being used (although intel_gpu_top just has it shoved under 'unknown', but without KNLMeansCL in the script, there is no usage under that category; with it in the script, and trying to process an 8K video, it's sitting around 17% or so).